### PR TITLE
Change crate name (not package name) from `loopdev_erikh` to `loopdev`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ readme = "README.md"
 keywords = ["loop", "losetup"]
 edition = "2021"
 
+[lib]
+name = "loopdev"
+
 [features]
 direct_io = []
 


### PR DESCRIPTION
By default, Cargo names library crates by taking the Cargo package's name and replacing `-` by `_`. So the package here is `loopdev-erikh` while the library crate contained inside of it is `loopdev_erikh`.

I propose keeping `loopdev-erikh` for the package name but using `loopdev` as the crate name.

```toml
# downstream Cargo.toml

[dependencies]
loopdev-erikh = "0.5"
```

```rust
// downstream main.rs

use loopdev::LoopControl;
```

This is a more convenient way to maintain a fork because the fork becomes a drop-in replacement for the original unmaintained library, without needing to touch Rust source code to change imports or add `extern crate loopdev_erikh as loopdev` or insert `{ package = "loopdev" }` into Cargo manifests.